### PR TITLE
expose src to package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-libs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@oat-sa/tao-core-libs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "TAO Frontent Core Libraries",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
In order to use the sources from an app, in ES2015 format, we need to expose the `src` folder in the npm package.