### PR TITLE
Fix/ncc-126/remove ua lang and fix transpaling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-libs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-libs",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "TAO Frontent Core Libraries",
     "files": [
         "dist",

--- a/src/select2.js
+++ b/src/select2.js
@@ -121,9 +121,6 @@ switch (lang) {
     case 'tr':
         import('select2-origin/select2_locale_tr');
         break;
-    case 'ua':
-        import('select2-origin/select2_locale_ua');
-        break;
     case 'vi':
         import('select2-origin/select2_locale_vi');
         break;

--- a/src/select2.js
+++ b/src/select2.js
@@ -1,13 +1,13 @@
 import 'select2-origin/select2';
 
-const getUserLanguage = () => {
-    const documentLang = window.document.documentElement.getAttribute('lang');
-    const documentLocale = documentLang && documentLang.split('-')[0];
+function getUserLanguage() {
+    var documentLang = window.document.documentElement.getAttribute('lang');
+    var documentLocale = documentLang && documentLang.split('-')[0];
 
     return documentLocale;
-};
+}
 
-const lang = getUserLanguage();
+var lang = getUserLanguage();
 
 switch (lang) {
     case 'ar':


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/NCC-126
**Description:** Remove import for UA language because of the original "select2" ~version 3.5 module doesn't provide translations.
Switch to ES3 syntax, transcompiler is missed in the building process
 