### PR TITLE
Fix/Add a missing alias to the select2 wrapper

### DIFF
--- a/src/pathdefinition.js
+++ b/src/pathdefinition.js
@@ -14,6 +14,7 @@ export default {
     'lib/popper/tooltip': '/node_modules/tooltip.js/dist/umd/tooltip',
     popper: '/node_modules/popper.js/dist/umd/popper',
     raphael: '/node_modules/raphael/raphael',
+    'select2': '/node_modules/@oat-sa/tao-core-libs/dist/select2',
     'select2-origin': '/node_modules/select2',
 
     // locals


### PR DESCRIPTION
Add an alias to the select2 wrapper that should replace the npm supplied version.

The `pathdefinition` file is used by the consumer packages to refer to the correct `select2` resource.

Note: This was forgotten from the PR https://github.com/oat-sa/tao-core-libs-fe/pull/16