### PR TITLE
Update raphael to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -511,9 +511,10 @@
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
-        "eve": {
-            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
+        "eve-raphael": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
+            "integrity": "sha1-F8dUt5K+7z+maE15z1pHxjxM2jA=",
             "dev": true
         },
         "external-editor": {
@@ -1151,12 +1152,12 @@
             "dev": true
         },
         "raphael": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.1.4.tgz",
-            "integrity": "sha1-sJymZK0Ei4FLsv9dTR51g4yrnJc=",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
+            "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
             "dev": true,
             "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+                "eve-raphael": "0.5.0"
             }
         },
         "regexpp": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "moment": "2.11.1",
         "moment-timezone": "0.5.10",
         "popper.js": "1.15.0",
-        "raphael": "2.2.0",
+        "raphael": "2.3.0",
         "select2": "3.5.1",
         "tooltip.js": "1.3.2"
     },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "moment": "2.11.1",
         "moment-timezone": "0.5.10",
         "popper.js": "1.15.0",
-        "raphael": "2.1.4",
+        "raphael": "2.3.0",
         "rollup": "^1.12.3",
         "rollup-plugin-alias": "^1.5.2",
         "rollup-plugin-copy": "^3.1.0",


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3287

 - update rahpael to 2.3.0 in order to get rid of the subdependency to `eve` using `git://`