### PR TITLE
Fix/ADF-1166/Broken Glob pattern in Windows

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -26,7 +26,8 @@ import { copyFile, mkdirp } from 'fs-extra';
 const Handlebars = require('handlebars');
 
 const { srcDir, outputDir, aliases } = require('./path.js');
-let inputs = glob.sync(path.join(srcDir, '**', '*.js'));
+const globPath = p => p.replace(/\\/g, '/');
+let inputs = glob.sync(globPath(path.join(srcDir, '**', '*.js')));
 
 /**
  * class.js cannot be built, because it is not 'use strict' valid
@@ -88,7 +89,7 @@ export default inputs.map(input => {
  * It is asyncronous and it was made with purpose to run parallely with build,
  * because they do not effect each other
  */
-glob(path.join(srcDir, '**', '*.tpl')).then(files => {
+glob(globPath(path.join(srcDir, '**', '*.tpl'))).then(files => {
     files.forEach(async file => {
         const targetFile = path.resolve(outputDir, path.relative(srcDir, file));
         await mkdirp(path.dirname(targetFile));


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1166

### Summary

Make sure to use forward-slash only in glob pattern.

### Details

Recently the dependencies were updated for fixing a few issues.
However, it also introduced a breaking change with Windows users as `node-glob` now reserves the back-slashes for escaping only.

See: https://github.com/isaacs/node-glob/blob/main/changelog.md#80

### How to test
- checkout the branch
- install it: `npm i`
- it should work seamlessly under Windows as well as in other systems