### PR TITLE
Feature/TR-5209/Cleanup calculator engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -415,12 +415,6 @@
                 }
             }
         },
-        "@oat-sa/expr-eval": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/expr-eval/-/expr-eval-1.3.1.tgz",
-            "integrity": "sha512-pUVOvkgWiydBmrxOEcmuLOWU9/1ZJZZ4Iped07Qf6P/E0mYVaEaKkBLRBfSyL1NuwX9VZPjxZ7qzfAi7zGJ88Q==",
-            "dev": true
-        },
         "@oat-sa/prettier-config": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@oat-sa/prettier-config/-/prettier-config-0.1.1.tgz",
@@ -1117,12 +1111,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-            "dev": true
-        },
-        "decimal.js": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.1.1.tgz",
-            "integrity": "sha512-vEEgyk1fWVEnv7lPjkNedAIjzxQDue5Iw4FeX4UkNUDSVyD/jZTD0Bw2kAO7k6iyyJRAhM9oxxI0D1ET6k0Mmg==",
             "dev": true
         },
         "deep-is": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     },
     "homepage": "https://github.com/oat-sa/tao-core-libs-fe#readme",
     "peerDependencies": {
-        "@oat-sa/expr-eval": "1.3.1",
         "async": "0.2.10",
-        "decimal.js": "10.1.1",
         "dompurify": "^2.4.0",
         "gamp": "0.2.1",
         "handlebars": "1.3.0",
@@ -53,12 +51,10 @@
     },
     "devDependencies": {
         "@oat-sa/eslint-config-tao": "^1.1.1",
-        "@oat-sa/expr-eval": "1.3.1",
         "@oat-sa/prettier-config": "^0.1.1",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-qunit-testrunner": "^1.0.3",
         "async": "0.2.10",
-        "decimal.js": "10.1.1",
         "dompurify": "^2.4.0",
         "eslint": "^8.25.0",
         "eslint-plugin-es": "^4.1.0",


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-5209

### Summary

Remove dependencies used by the calculator since it has moved to a dedicated package: [tao-calculator](https://github.com/oat-sa/tao-calculator-fe)

### Details

Remove unused dependencies: `expr-eval`, `decimal.js`

### How to test
- install: `npm i`
- run the tests `npm test`
